### PR TITLE
Publish FileUploadValidationSuccessful event

### DIFF
--- a/.devcontainer/.dev_config.yaml
+++ b/.devcontainer/.dev_config.yaml
@@ -1,8 +1,12 @@
 # Please only mention the non-default settings here:
 
 service_name: fis
-token_hashes: [abcdef, ghijkl]
+source_bucket_id: test-staging
 private_key: dummy-key
+token_hashes: [abcdef, ghijkl]
+
+publisher_topic: file_interrogation
+publisher_type: file_validation_success
 
 vault_host: "http://127.0.0.1"
 vault_port: 8200

--- a/.devcontainer/.dev_config.yaml
+++ b/.devcontainer/.dev_config.yaml
@@ -8,6 +8,9 @@ token_hashes: [abcdef, ghijkl]
 publisher_topic: file_interrogation
 publisher_type: file_validation_success
 
+service_instance_id: 001
+kafka_servers: ["kafka:9092"]
+
 vault_host: "http://127.0.0.1"
 vault_port: 8200
 vault_role_id: dummy-role

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ The service requires the following configuration parameters:
 
   - **Items** *(string)*
 
+- **`service_name`** *(string)*: Default: `fis`.
+
+- **`service_instance_id`** *(string)*: A string that uniquely identifies this instance across all instances of this service. A globally unique Kafka client ID will be created by concatenating the service_name and the service_instance_id.
+
+- **`kafka_servers`** *(array)*: A list of connection strings to connect to Kafka bootstrap servers.
+
+  - **Items** *(string)*
+
 - **`publisher_topic`** *(string)*: Topic name expected by downstream services. Use the topic name from the interrogation room service.
 
 - **`publisher_type`** *(string)*: Type expected by downstream services. Use the type from the interrogation room service.
@@ -101,8 +109,6 @@ The service requires the following configuration parameters:
 - **`cors_allowed_headers`** *(array)*: A list of HTTP request headers that should be supported for cross-origin requests. Defaults to []. You can use ['*'] to allow all headers. The Accept, Accept-Language, Content-Language and Content-Type headers are always allowed for CORS requests.
 
   - **Items** *(string)*
-
-- **`service_name`** *(string)*: Default: `fis`.
 
 
 ### Usage:

--- a/README.md
+++ b/README.md
@@ -60,11 +60,17 @@ The service requires the following configuration parameters:
 
 - **`vault_secret_id`** *(string)*: Vault secret ID to access a specific prefix.
 
+- **`private_key`** *(string)*
+
+- **`source_bucket_id`** *(string)*
+
 - **`token_hashes`** *(array)*
 
   - **Items** *(string)*
 
-- **`private_key`** *(string)*
+- **`publisher_topic`** *(string)*: Topic name expected by downstream services. Use the topic name from the interrogation room service.
+
+- **`publisher_type`** *(string)*: Type expected by downstream services. Use the type from the interrogation room service.
 
 - **`host`** *(string)*: IP of the host. Default: `127.0.0.1`.
 

--- a/config_schema.json
+++ b/config_schema.json
@@ -77,6 +77,37 @@
         "type": "string"
       }
     },
+    "service_name": {
+      "title": "Service Name",
+      "default": "fis",
+      "env_names": [
+        "fis_service_name"
+      ],
+      "type": "string"
+    },
+    "service_instance_id": {
+      "title": "Service Instance Id",
+      "description": "A string that uniquely identifies this instance across all instances of this service. A globally unique Kafka client ID will be created by concatenating the service_name and the service_instance_id.",
+      "example": "germany-bw-instance-001",
+      "env_names": [
+        "fis_service_instance_id"
+      ],
+      "type": "string"
+    },
+    "kafka_servers": {
+      "title": "Kafka Servers",
+      "description": "A list of connection strings to connect to Kafka bootstrap servers.",
+      "example": [
+        "localhost:9092"
+      ],
+      "env_names": [
+        "fis_kafka_servers"
+      ],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "publisher_topic": {
       "title": "Publisher Topic",
       "description": "Topic name expected by downstream services. Use the topic name from the interrogation room service.",
@@ -227,14 +258,6 @@
       "items": {
         "type": "string"
       }
-    },
-    "service_name": {
-      "title": "Service Name",
-      "default": "fis",
-      "env_names": [
-        "fis_service_name"
-      ],
-      "type": "string"
     }
   },
   "required": [
@@ -245,6 +268,8 @@
     "private_key",
     "source_bucket_id",
     "token_hashes",
+    "service_instance_id",
+    "kafka_servers",
     "publisher_topic",
     "publisher_type"
   ],

--- a/config_schema.json
+++ b/config_schema.json
@@ -53,6 +53,20 @@
       "writeOnly": true,
       "format": "password"
     },
+    "private_key": {
+      "title": "Private Key",
+      "env_names": [
+        "fis_private_key"
+      ],
+      "type": "string"
+    },
+    "source_bucket_id": {
+      "title": "Source Bucket Id",
+      "env_names": [
+        "fis_source_bucket_id"
+      ],
+      "type": "string"
+    },
     "token_hashes": {
       "title": "Token Hashes",
       "env_names": [
@@ -63,10 +77,21 @@
         "type": "string"
       }
     },
-    "private_key": {
-      "title": "Private Key",
+    "publisher_topic": {
+      "title": "Publisher Topic",
+      "description": "Topic name expected by downstream services. Use the topic name from the interrogation room service.",
+      "example": "file_interrogation",
       "env_names": [
-        "fis_private_key"
+        "fis_publisher_topic"
+      ],
+      "type": "string"
+    },
+    "publisher_type": {
+      "title": "Publisher Type",
+      "description": "Type expected by downstream services. Use the type from the interrogation room service.",
+      "example": "file_validation_success",
+      "env_names": [
+        "fis_publisher_type"
       ],
       "type": "string"
     },
@@ -217,8 +242,11 @@
     "vault_port",
     "vault_role_id",
     "vault_secret_id",
+    "private_key",
+    "source_bucket_id",
     "token_hashes",
-    "private_key"
+    "publisher_topic",
+    "publisher_type"
   ],
   "additionalProperties": false
 }

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -7,12 +7,15 @@ cors_allowed_origins: null
 debug_vault: false
 docs_url: /docs
 host: 127.0.0.1
+kafka_servers:
+- kafka:9092
 log_level: info
 openapi_url: /openapi.json
 port: 8080
 private_key: dummy-key
 publisher_topic: file_interrogation
 publisher_type: file_validation_success
+service_instance_id: '1'
 service_name: fis
 source_bucket_id: test-staging
 token_hashes:

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -11,7 +11,10 @@ log_level: info
 openapi_url: /openapi.json
 port: 8080
 private_key: dummy-key
+publisher_topic: file_interrogation
+publisher_type: file_validation_success
 service_name: fis
+source_bucket_id: test-staging
 token_hashes:
 - abcdef
 - ghijkl

--- a/fis/adapters/inbound/fastapi_/http_authorization.py
+++ b/fis/adapters/inbound/fastapi_/http_authorization.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Authorization specific code for FastAPI"""
 
-from dependency_injector.wiring import Provide
+from dependency_injector.wiring import Provide, inject
 from fastapi import Depends, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from ghga_service_commons.auth.context import AuthContextProtocol
@@ -53,6 +53,7 @@ class IngestTokenAuthProvider(AuthContextProtocol[IngestTokenAuthContext]):
         return IngestTokenAuthContext(token=token)
 
 
+@inject
 async def require_token_context(
     service_config: ServiceConfig = Depends(Provide[Container.config]),
     credentials: HTTPAuthorizationCredentials = Depends(HTTPBearer(auto_error=True)),

--- a/fis/adapters/inbound/fastapi_/routes.py
+++ b/fis/adapters/inbound/fastapi_/routes.py
@@ -59,8 +59,14 @@ async def ingest_file_upload_metadata(
     file_secret = decrypted_metadata.file_secret
 
     try:
-        _ = await upload_metadata_processor.store_secret(file_secret=file_secret)
+        secret_id = await upload_metadata_processor.store_secret(
+            file_secret=file_secret
+        )
     except upload_metadata_processor.VaultCommunicationError as error:
         raise HTTPException(status_code=500, detail=str(error)) from error
+
+    await upload_metadata_processor.populate_by_event(
+        upload_metadata=decrypted_metadata, secret_id=secret_id
+    )
 
     return Response(status_code=202)

--- a/fis/config.py
+++ b/fis/config.py
@@ -16,6 +16,7 @@
 
 from ghga_service_commons.api import ApiConfigBase
 from hexkit.config import config_from_yaml
+from hexkit.providers.akafka import KafkaConfig
 
 from fis.adapters.outbound.event_pub import EventPubTranslatorConfig
 from fis.adapters.outbound.vault import VaultConfig
@@ -24,7 +25,9 @@ from fis.core.ingest import ServiceConfig
 
 # Please adapt config prefix and remove unnecessary config bases:
 @config_from_yaml(prefix="fis")
-class Config(ApiConfigBase, EventPubTranslatorConfig, ServiceConfig, VaultConfig):
+class Config(
+    ApiConfigBase, EventPubTranslatorConfig, KafkaConfig, ServiceConfig, VaultConfig
+):
     """Config parameters and their defaults."""
 
     service_name: str = "fis"

--- a/fis/config.py
+++ b/fis/config.py
@@ -25,8 +25,12 @@ from fis.core.ingest import ServiceConfig
 
 # Please adapt config prefix and remove unnecessary config bases:
 @config_from_yaml(prefix="fis")
-class Config(
-    ApiConfigBase, EventPubTranslatorConfig, KafkaConfig, ServiceConfig, VaultConfig
+class Config(  # noqa: R0901
+    ApiConfigBase,
+    EventPubTranslatorConfig,
+    KafkaConfig,
+    ServiceConfig,
+    VaultConfig,
 ):
     """Config parameters and their defaults."""
 

--- a/fis/config.py
+++ b/fis/config.py
@@ -25,7 +25,7 @@ from fis.core.ingest import ServiceConfig
 
 # Please adapt config prefix and remove unnecessary config bases:
 @config_from_yaml(prefix="fis")
-class Config(  # noqa: R0901
+class Config(  # pylint: disable=too-many-ancestors
     ApiConfigBase,
     EventPubTranslatorConfig,
     KafkaConfig,

--- a/fis/config.py
+++ b/fis/config.py
@@ -17,13 +17,14 @@
 from ghga_service_commons.api import ApiConfigBase
 from hexkit.config import config_from_yaml
 
+from fis.adapters.outbound.event_pub import EventPubTranslatorConfig
 from fis.adapters.outbound.vault import VaultConfig
 from fis.core.ingest import ServiceConfig
 
 
 # Please adapt config prefix and remove unnecessary config bases:
 @config_from_yaml(prefix="fis")
-class Config(ApiConfigBase, ServiceConfig, VaultConfig):
+class Config(ApiConfigBase, EventPubTranslatorConfig, ServiceConfig, VaultConfig):
     """Config parameters and their defaults."""
 
     service_name: str = "fis"

--- a/fis/container.py
+++ b/fis/container.py
@@ -16,7 +16,9 @@
 
 
 from hexkit.inject import ContainerBase, get_configurator, get_constructor
+from hexkit.providers.akafka import KafkaEventPublisher
 
+from fis.adapters.outbound.event_pub import EventPubTranslator
 from fis.adapters.outbound.vault import VaultAdapter
 from fis.config import Config
 from fis.core.ingest import UploadMetadataProcessor
@@ -26,7 +28,15 @@ class Container(ContainerBase):
     """DI Container"""
 
     config = get_configurator(Config)
+    event_pub_provider = get_constructor(KafkaEventPublisher, config=config)
+    event_publisher = get_constructor(
+        EventPubTranslator, config=config, provider=event_pub_provider
+    )
     vault_adapter = get_constructor(VaultAdapter, config=config)
+
     upload_metadata_processor = get_constructor(
-        UploadMetadataProcessor, config=config, vault_adapter=vault_adapter
+        UploadMetadataProcessor,
+        config=config,
+        event_publisher=event_publisher,
+        vault_adapter=vault_adapter,
     )

--- a/fis/main.py
+++ b/fis/main.py
@@ -61,6 +61,11 @@ async def run_rest():
     config = Config()
 
     async with get_configured_container(config=config) as container:
-        container.wire(modules=["fis.adapters.inbound.fastapi_.routes"])
+        container.wire(
+            modules=[
+                "fis.adapters.inbound.fastapi_.http_authorization",
+                "fis.adapters.inbound.fastapi_.routes",
+            ]
+        )
         api = get_rest_api(config=config)
         await run_server(app=api, config=config)

--- a/fis/ports/inbound/ingest.py
+++ b/fis/ports/inbound/ingest.py
@@ -16,8 +16,6 @@
 
 from abc import ABC, abstractmethod
 
-from ghga_event_schemas.pydantic_ import FileUploadValidationSuccess
-
 from fis.core import models
 
 
@@ -51,7 +49,9 @@ class UploadMetadataProcessorPort(ABC):
         """Decrypt upload metadata using private key"""
 
     @abstractmethod
-    async def populate_by_event(self, *, event: FileUploadValidationSuccess):
+    async def populate_by_event(
+        self, *, upload_metadata: models.FileUploadMetadata, secret_id: str
+    ):
         """Send FileUploadValidationSuccess event to be processed by downstream services"""
 
     @abstractmethod

--- a/fis/ports/outbound/event_pub.py
+++ b/fis/ports/outbound/event_pub.py
@@ -14,8 +14,20 @@
 # limitations under the License.
 """Interface for broadcasting events to other services."""
 
-from abc import ABC
+from abc import ABC, abstractmethod
+
+from fis.core.models import FileUploadMetadata
 
 
 class EventPublisherPort(ABC):
     """A port through which ingest events are communicated with the file backend services."""
+
+    @abstractmethod
+    async def send_file_metadata(
+        self,
+        *,
+        upload_metadata: FileUploadMetadata,
+        source_bucket_id: str,
+        secret_id: str
+    ):
+        """Send FileUploadValidationSuccess event to downstream services"""

--- a/tests/fixtures/joint.py
+++ b/tests/fixtures/joint.py
@@ -31,7 +31,7 @@ from ghga_service_commons.utils.crypt import (
 from ghga_service_commons.utils.simple_token import generate_token_and_hash
 from hexkit.providers.akafka.testutils import KafkaFixture, kafka_fixture  # noqa: F401
 
-from fis.config import ServiceConfig
+from fis.config import Config, ServiceConfig
 from fis.container import Container
 from fis.core.models import FileUploadMetadata, FileUploadMetadataEncrypted
 from fis.main import get_configured_container, get_rest_api
@@ -54,6 +54,7 @@ TEST_PAYLOAD = FileUploadMetadata(
 class JointFixture:
     """Holds generated test keypair and configured container"""
 
+    config: Config
     container: Container
     keypair: KeyPair
     token: str
@@ -99,6 +100,7 @@ async def joint_fixture(
 
     async with AsyncTestClient(app=api) as rest_client:
         yield JointFixture(
+            config=config,
             container=container,
             keypair=keypair,
             payload=TEST_PAYLOAD,

--- a/tests/fixtures/joint.py
+++ b/tests/fixtures/joint.py
@@ -1,0 +1,109 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import base64
+import os
+from dataclasses import dataclass
+from typing import AsyncGenerator
+
+import httpx
+import pytest_asyncio
+from ghga_service_commons.api.testing import AsyncTestClient
+from ghga_service_commons.utils.crypt import (
+    KeyPair,
+    encode_key,
+    encrypt,
+    generate_key_pair,
+)
+from ghga_service_commons.utils.simple_token import generate_token_and_hash
+from hexkit.providers.akafka.testutils import KafkaFixture, kafka_fixture  # noqa: F401
+
+from fis.config import ServiceConfig
+from fis.container import Container
+from fis.core.models import FileUploadMetadata, FileUploadMetadataEncrypted
+from fis.main import get_configured_container, get_rest_api
+from tests.fixtures.config import get_config
+
+TEST_PAYLOAD = FileUploadMetadata(
+    file_id="abc",
+    object_id="happy_little_object",
+    part_size=16 * 1024**2,
+    unencrypted_size=50 * 1024**2,
+    encrypted_size=50 * 1024**2 + 128,
+    file_secret=base64.b64encode(os.urandom(32)).decode(),
+    unencrypted_checksum="def",
+    encrypted_md5_checksums=["a", "b", "c"],
+    encrypted_sha256_checksums=["a", "b", "c"],
+)
+
+
+@dataclass
+class JointFixture:
+    """Holds generated test keypair and configured container"""
+
+    container: Container
+    keypair: KeyPair
+    token: str
+    payload: FileUploadMetadata
+    encrypted_payload: FileUploadMetadataEncrypted
+    kafka: KafkaFixture
+    rest_client: httpx.AsyncClient
+
+
+@pytest_asyncio.fixture
+async def joint_fixture(
+    kafka_fixture: KafkaFixture,  # noqa: F811
+) -> AsyncGenerator[JointFixture, None]:
+    """Generate keypair for testing and setup container with updated config"""
+
+    keypair = generate_key_pair()
+    private_key = encode_key(key=keypair.private)
+
+    token, token_hash = generate_token_and_hash()
+
+    service_config = ServiceConfig(
+        source_bucket_id="test-staging",
+        private_key=private_key,
+        token_hashes=[token_hash],
+    )
+    config = get_config(sources=[kafka_fixture.config, service_config])
+    container = get_configured_container(config=config)
+    container.wire(
+        modules=[
+            "fis.adapters.inbound.fastapi_.http_authorization",
+            "fis.adapters.inbound.fastapi_.routes",
+        ]
+    )
+
+    encrypted_payload = FileUploadMetadataEncrypted(
+        payload=encrypt(
+            data=TEST_PAYLOAD.json(),
+            key=keypair.public,
+        )
+    )
+
+    api = get_rest_api(config=config)
+
+    async with AsyncTestClient(app=api) as rest_client:
+        yield JointFixture(
+            container=container,
+            keypair=keypair,
+            payload=TEST_PAYLOAD,
+            encrypted_payload=encrypted_payload,
+            token=token,
+            kafka=kafka_fixture,
+            rest_client=rest_client,
+        )

--- a/tests/fixtures/test_config.yaml
+++ b/tests/fixtures/test_config.yaml
@@ -1,6 +1,10 @@
 service_name: fis
-token_hashes: [abcdef, ghijkl]
+source_bucket_id: test-staging
 private_key: dummy-key
+token_hashes: [abcdef, ghijkl]
+
+publisher_topic: file_interrogation
+publisher_type: file_validation_success
 
 vault_host: "http://127.0.0.1"
 vault_port: 8200

--- a/tests/fixtures/test_config.yaml
+++ b/tests/fixtures/test_config.yaml
@@ -6,6 +6,9 @@ token_hashes: [abcdef, ghijkl]
 publisher_topic: file_interrogation
 publisher_type: file_validation_success
 
+service_instance_id: 001
+kafka_servers: ["kafka:9092"]
+
 vault_host: "http://127.0.0.1"
 vault_port: 8200
 vault_role_id: dummy-role

--- a/tests/test_api_call.py
+++ b/tests/test_api_call.py
@@ -1,0 +1,61 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Test actual API call and event publishing"""
+
+import pytest
+
+from tests.fixtures.joint import (  # noqa: F401
+    JointFixture,
+    KafkaFixture,
+    joint_fixture,
+    kafka_fixture,
+)
+
+
+@pytest.mark.asyncio
+async def test_api_call(monkeypatch, joint_fixture: JointFixture):  # noqa: F811
+    """Test functionality with incoming API call"""
+
+    # test happy path
+    headers = {"Authorization": f"Bearer {joint_fixture.token}"}
+
+    # patch vault call with mock
+    with monkeypatch.context() as patch:
+        patch.setattr(
+            "fis.adapters.outbound.vault.client.VaultAdapter.store_secret",
+            lambda self, secret: "very_secret_id",
+        )
+        response = await joint_fixture.rest_client.post(
+            "/ingest", json=joint_fixture.encrypted_payload.dict(), headers=headers
+        )
+
+    assert response.status_code == 202
+
+    # test missing authorization
+    response = await joint_fixture.rest_client.post(
+        "/ingest", json=joint_fixture.encrypted_payload.dict()
+    )
+    assert response.status_code == 403
+
+    # test malformed payload
+    nonsense_payload = joint_fixture.encrypted_payload.copy(
+        update={"payload": "abcdefghijklmn"}
+    )
+    response = await joint_fixture.rest_client.post(
+        "/ingest", json=nonsense_payload.dict(), headers=headers
+    )
+    assert response.status_code == 422

--- a/tests/test_api_call.py
+++ b/tests/test_api_call.py
@@ -17,6 +17,12 @@
 """Test actual API call and event publishing"""
 
 import pytest
+from ghga_event_schemas.pydantic_ import FileUploadValidationSuccess
+from hexkit.providers.akafka.testutils import (
+    EventRecorder,
+    ExpectedEvent,
+    check_recorded_events,
+)
 
 from tests.fixtures.joint import (  # noqa: F401
     JointFixture,
@@ -30,6 +36,13 @@ from tests.fixtures.joint import (  # noqa: F401
 async def test_api_call(monkeypatch, joint_fixture: JointFixture):  # noqa: F811
     """Test functionality with incoming API call"""
 
+    event_recorder = EventRecorder(
+        kafka_servers=joint_fixture.kafka.config.kafka_servers,
+        topic=joint_fixture.config.publisher_topic,
+    )
+
+    secret_id = "very_secret_id"
+
     # test happy path
     headers = {"Authorization": f"Bearer {joint_fixture.token}"}
 
@@ -37,13 +50,43 @@ async def test_api_call(monkeypatch, joint_fixture: JointFixture):  # noqa: F811
     with monkeypatch.context() as patch:
         patch.setattr(
             "fis.adapters.outbound.vault.client.VaultAdapter.store_secret",
-            lambda self, secret: "very_secret_id",
+            lambda self, secret: secret_id,
         )
-        response = await joint_fixture.rest_client.post(
-            "/ingest", json=joint_fixture.encrypted_payload.dict(), headers=headers
-        )
+        async with event_recorder:
+            response = await joint_fixture.rest_client.post(
+                "/ingest", json=joint_fixture.encrypted_payload.dict(), headers=headers
+            )
 
     assert response.status_code == 202
+    assert len(event_recorder.recorded_events) == 1
+
+    # can't get exact event time for equality comparison, don't check but get directly
+    # from the recorded event instead
+    expected_upload_date = str(event_recorder.recorded_events[0].payload["upload_date"])
+
+    payload = FileUploadValidationSuccess(
+        upload_date=expected_upload_date,
+        file_id=joint_fixture.payload.file_id,
+        source_object_id=joint_fixture.payload.object_id,
+        source_bucket_id=joint_fixture.config.source_bucket_id,
+        decrypted_size=joint_fixture.payload.unencrypted_size,
+        decryption_secret_id=secret_id,
+        content_offset=0,
+        encrypted_part_size=joint_fixture.payload.part_size,
+        encrypted_parts_md5=joint_fixture.payload.encrypted_md5_checksums,
+        encrypted_parts_sha256=joint_fixture.payload.encrypted_sha256_checksums,
+        decrypted_sha256=joint_fixture.payload.unencrypted_checksum,
+    )
+
+    expected_event = ExpectedEvent(
+        payload=payload.dict(),
+        type_=joint_fixture.config.publisher_type,
+        key=joint_fixture.payload.file_id,
+    )
+
+    check_recorded_events(
+        recorded_events=event_recorder.recorded_events, expected_events=[expected_event]
+    )
 
     # test missing authorization
     response = await joint_fixture.rest_client.post(

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -15,88 +15,45 @@
 
 """Test ingest functions"""
 
-import base64
-import os
-
 import pytest
-from ghga_service_commons.utils.crypt import encode_key, encrypt, generate_key_pair
+from ghga_service_commons.utils.crypt import encrypt, generate_key_pair
 
-from fis.config import ServiceConfig
-from fis.core.models import FileUploadMetadata, FileUploadMetadataEncrypted
-from fis.main import get_configured_container
-from tests.fixtures.config import get_config
+from fis.core.models import FileUploadMetadataEncrypted
+from tests.fixtures.joint import (  # noqa: F401
+    JointFixture,
+    KafkaFixture,
+    joint_fixture,
+    kafka_fixture,
+)
 
 
 @pytest.mark.asyncio
-async def test_decryption_happy():
+async def test_decryption_happy(joint_fixture: JointFixture):  # noqa: F811
     """Test decryption with valid keypair and correct file upload metadata format."""
 
-    # setup, move into fixture later
-    keypair = generate_key_pair()
-    private_key = encode_key(key=keypair.private)
-
-    patched_service_config = ServiceConfig(token_hashes=[], private_key=private_key)
-    config = get_config(sources=[patched_service_config])
-    container = get_configured_container(config=config)
-    container.wire(modules=["fis.adapters.inbound.fastapi_.routes"])
-
-    # actual test code
-    upload_metadata_processor = container.upload_metadata_processor()
-
-    decrypted_payload = FileUploadMetadata(
-        file_id="abc",
-        object_id="happy_little_object",
-        part_size=16 * 1024**2,
-        unencrypted_size=50 * 1024**2,
-        encrypted_size=50 * 1024**2 + 128,
-        file_secret=base64.b64encode(os.urandom(32)).decode(),
-        unencrypted_checksum="def",
-        encrypted_md5_checksums=["a", "b", "c"],
-        encrypted_sha256_checksums=["a", "b", "c"],
-    )
-
-    encrypted_payload = FileUploadMetadataEncrypted(
-        payload=encrypt(data=decrypted_payload.json(), key=keypair.public)
+    upload_metadata_processor = (
+        await joint_fixture.container.upload_metadata_processor()
     )
 
     processed_payload = await upload_metadata_processor.decrypt_payload(
-        encrypted=encrypted_payload
+        encrypted=joint_fixture.encrypted_payload
     )
-    assert processed_payload == decrypted_payload
+    assert processed_payload == joint_fixture.payload
 
 
 @pytest.mark.asyncio
-async def test_decryption_sad():
+async def test_decryption_sad(joint_fixture: JointFixture):  # noqa: F811
     """Test decryption throws correct errors for payload and key issues"""
 
-    # setup, move into fixture later
-    keypair = generate_key_pair()
-    private_key = encode_key(key=keypair.private)
-
-    patched_service_config = ServiceConfig(token_hashes=[], private_key=private_key)
-    config = get_config(sources=[patched_service_config])
-    container = get_configured_container(config=config)
-    container.wire(modules=["fis.adapters.inbound.fastapi_.routes"])
-
-    # actual test code
-    decrypted_payload = FileUploadMetadata(
-        file_id="abc",
-        object_id="happy_little_object",
-        part_size=16 * 1024**2,
-        unencrypted_size=50 * 1024**2,
-        encrypted_size=50 * 1024**2 + 128,
-        file_secret=base64.b64encode(os.urandom(32)).decode(),
-        unencrypted_checksum="def",
-        encrypted_md5_checksums=["a", "b", "c"],
-        encrypted_sha256_checksums=["a", "b", "c"],
+    upload_metadata_processor = (
+        await joint_fixture.container.upload_metadata_processor()
     )
-
-    upload_metadata_processor = container.upload_metadata_processor()
 
     # test faulty payload
     encrypted_payload = FileUploadMetadataEncrypted(
         payload=encrypt(
-            data=decrypted_payload.json(exclude={"file_secret"}), key=keypair.public
+            data=joint_fixture.payload.json(exclude={"file_secret"}),
+            key=joint_fixture.keypair.public,
         )
     )
 
@@ -107,7 +64,7 @@ async def test_decryption_sad():
     keypair2 = generate_key_pair()
 
     encrypted_payload = FileUploadMetadataEncrypted(
-        payload=encrypt(data=decrypted_payload.json(), key=keypair2.public)
+        payload=encrypt(data=joint_fixture.payload.json(), key=keypair2.public)
     )
 
     with pytest.raises(upload_metadata_processor.DecryptionError):


### PR DESCRIPTION
```
Added event publisher
Moved common test stuff into fixture
Added test for API call and expected event
```

Had to set some defaults for the outgoing event:
 - We don't have the offset information in the local upload metadata - do we even need that anymore?
 - creation_date/upload_date is set to now_as_utc