### PR TITLE
Added endpoints for new secret handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/file-ingest-service):
 ```bash
-docker pull ghga/file-ingest-service:0.1.5
+docker pull ghga/file-ingest-service:0.1.6
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/file-ingest-service:0.1.5 .
+docker build -t ghga/file-ingest-service:0.1.6 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -35,7 +35,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/file-ingest-service:0.1.5 --help
+docker run -p 8080:8080 ghga/file-ingest-service:0.1.6 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,14 +1,17 @@
 components:
   schemas:
-    FileUploadMetadataEncrypted:
-      description: Encrypted file upload metadata model
+    EncryptedPayload:
+      description: 'Generic model for an encrypted payload.
+
+
+        Can correspond to current/legacy upload metadata or a file secret.'
       properties:
         payload:
           title: Payload
           type: string
       required:
       - payload
-      title: FileUploadMetadataEncrypted
+      title: EncryptedPayload
       type: object
     HTTPValidationError:
       properties:
@@ -51,6 +54,63 @@ info:
   version: 0.1.5
 openapi: 3.0.2
 paths:
+  /federated/ingest_metadata:
+    post:
+      description: Decrypt payload, process metadata, file secret and send success
+        event
+      operationId: ingestFileUploadMetadata
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EncryptedPayload'
+        required: true
+      responses:
+        '202':
+          content:
+            application/json:
+              schema: {}
+          description: Received and decrypted data successfully.
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - HTTPBearer: []
+      summary: Processes encrypted output data from the S3 upload script and ingests
+        it into the Encryption Key Store, Internal File Registry and Download Controller.
+      tags:
+      - FileIngestService
+  /federated/ingest_secret:
+    post:
+      description: Decrypt payload, process metadata, file secret and send success
+        event
+      operationId: ingestSecret
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EncryptedPayload'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {}
+          description: Received and stored secret successfully.
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - HTTPBearer: []
+      summary: Store file encryption/decryption secret and return secret ID.
+      tags:
+      - FileIngestService
   /health:
     get:
       description: Used to test if this service is alive
@@ -64,16 +124,17 @@ paths:
       summary: health
       tags:
       - FileIngestService
-  /ingest:
+  /legacy/ingest:
     post:
+      deprecated: true
       description: Decrypt payload, process metadata, file secret and send success
         event
-      operationId: ingestFileUploadMetadata
+      operationId: ingestLegacyFileUploadMetadata
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/FileUploadMetadataEncrypted'
+              $ref: '#/components/schemas/EncryptedPayload'
         required: true
       responses:
         '202':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -51,12 +51,12 @@ info:
   description: A service to ingest s3 file upload metadata produced by thedata-steward-kit
     upload command
   title: File Ingest Service
-  version: 0.1.5
+  version: 0.1.6
 openapi: 3.0.2
 paths:
   /federated/ingest_metadata:
     post:
-      description: Decrypt payload, process metadata, file secret and send success
+      description: Decrypt payload, process metadata, file secret id and send success
         event
       operationId: ingestFileUploadMetadata
       requestBody:
@@ -85,8 +85,8 @@ paths:
       - FileIngestService
   /federated/ingest_secret:
     post:
-      description: Decrypt payload, process metadata, file secret and send success
-        event
+      description: Decrypt payload and deposit file secret in exchange for a secret
+        id
       operationId: ingestSecret
       requestBody:
         content:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fis"
-version = "0.1.5"
+version = "0.1.6"
 description = "File Ingest Service - A lightweight service to propagate file upload metadata to the GHGA file backend services"
 readme = "README.md"
 authors = [

--- a/src/fis/adapters/inbound/fastapi_/routes.py
+++ b/src/fis/adapters/inbound/fastapi_/routes.py
@@ -43,7 +43,7 @@ async def health():
     "/legacy/ingest",
     summary="Processes encrypted output data from the S3 upload script and ingests it "
     + "into the Encryption Key Store, Internal File Registry and Download Controller.",
-    operation_id="ingestFileUploadMetadata",
+    operation_id="ingestLegacyFileUploadMetadata",
     tags=["FileIngestService"],
     status_code=status.HTTP_202_ACCEPTED,
     response_description="Received and decrypted data successfully.",
@@ -123,12 +123,11 @@ async def ingest_metadata(
 
 @router.post(
     "/federated/ingest_secret",
-    summary="Processes encrypted output data from the S3 upload script and ingests it "
-    + "into the Encryption Key Store, Internal File Registry and Download Controller.",
-    operation_id="ingestFileUploadMetadata",
+    summary="Store file encryption/decryption secret and return secret ID.",
+    operation_id="ingestSecret",
     tags=["FileIngestService"],
     status_code=status.HTTP_200_OK,
-    response_description="Received and decrypted data successfully.",
+    response_description="Received and stored secret successfully.",
 )
 @inject
 async def ingest_secret(

--- a/src/fis/adapters/inbound/fastapi_/routes.py
+++ b/src/fis/adapters/inbound/fastapi_/routes.py
@@ -101,7 +101,7 @@ async def ingest_metadata(
     ),
     _token: IngestTokenAuthContext = require_token,
 ):
-    """Decrypt payload, process metadata, file secret and send success event"""
+    """Decrypt payload, process metadata, file secret id and send success event"""
     try:
         decrypted_metadata = await upload_metadata_processor.decrypt_payload(
             encrypted=encrypted_payload
@@ -137,7 +137,7 @@ async def ingest_secret(
     ),
     _token: IngestTokenAuthContext = require_token,
 ):
-    """Decrypt payload, process metadata, file secret and send success event"""
+    """Decrypt payload and deposit file secret in exchange for a secret id"""
     file_secret = await upload_metadata_processor.decrypt_secret(
         encrypted=encrypted_payload
     )

--- a/src/fis/adapters/inbound/fastapi_/routes.py
+++ b/src/fis/adapters/inbound/fastapi_/routes.py
@@ -85,7 +85,7 @@ async def ingest_legacy_metadata(
 
 
 @router.post(
-    "/federated/ingest_secret",
+    "/federated/ingest_metadata",
     summary="Processes encrypted output data from the S3 upload script and ingests it "
     + "into the Encryption Key Store, Internal File Registry and Download Controller.",
     operation_id="ingestFileUploadMetadata",

--- a/src/fis/adapters/inbound/fastapi_/routes.py
+++ b/src/fis/adapters/inbound/fastapi_/routes.py
@@ -22,8 +22,8 @@ from fis.adapters.inbound.fastapi_.http_authorization import (
     require_token,
 )
 from fis.container import Container
-from fis.core.ingest import UploadMetadataProcessorPort
-from fis.core.models import FileUploadMetadataEncrypted
+from fis.core.ingest import LegacyUploadMetadataProcessor, UploadMetadataProcessor
+from fis.core.models import EncryptedPayload
 
 router = APIRouter()
 
@@ -40,19 +40,20 @@ async def health():
 
 
 @router.post(
-    "/ingest",
+    "/legacy/ingest",
     summary="Processes encrypted output data from the S3 upload script and ingests it "
     + "into the Encryption Key Store, Internal File Registry and Download Controller.",
     operation_id="ingestFileUploadMetadata",
     tags=["FileIngestService"],
     status_code=status.HTTP_202_ACCEPTED,
     response_description="Received and decrypted data successfully.",
+    deprecated=True,
 )
 @inject
-async def ingest_file_upload_metadata(
-    encrypted_payload: FileUploadMetadataEncrypted,
-    upload_metadata_processor: UploadMetadataProcessorPort = Depends(
-        Provide[Container.upload_metadata_processor]
+async def ingest_legacy_metadata(
+    encrypted_payload: EncryptedPayload,
+    upload_metadata_processor: LegacyUploadMetadataProcessor = Depends(
+        Provide[Container.legacy_upload_metadata_processor]
     ),
     _token: IngestTokenAuthContext = require_token,
 ):
@@ -81,3 +82,66 @@ async def ingest_file_upload_metadata(
     )
 
     return Response(status_code=202)
+
+
+@router.post(
+    "/federated/ingest_secret",
+    summary="Processes encrypted output data from the S3 upload script and ingests it "
+    + "into the Encryption Key Store, Internal File Registry and Download Controller.",
+    operation_id="ingestFileUploadMetadata",
+    tags=["FileIngestService"],
+    status_code=status.HTTP_202_ACCEPTED,
+    response_description="Received and decrypted data successfully.",
+)
+@inject
+async def ingest_metadata(
+    encrypted_payload: EncryptedPayload,
+    upload_metadata_processor: UploadMetadataProcessor = Depends(
+        Provide[Container.upload_metadata_processor]
+    ),
+    _token: IngestTokenAuthContext = require_token,
+):
+    """Decrypt payload, process metadata, file secret and send success event"""
+    try:
+        decrypted_metadata = await upload_metadata_processor.decrypt_payload(
+            encrypted=encrypted_payload
+        )
+    except (
+        upload_metadata_processor.DecryptionError,
+        upload_metadata_processor.WrongDecryptedFormatError,
+    ) as error:
+        raise HTTPException(status_code=422, detail=str(error)) from error
+
+    secret_id = decrypted_metadata.secret_id
+
+    await upload_metadata_processor.populate_by_event(
+        upload_metadata=decrypted_metadata, secret_id=secret_id
+    )
+
+    return Response(status_code=202)
+
+
+@router.post(
+    "/federated/ingest_secret",
+    summary="Processes encrypted output data from the S3 upload script and ingests it "
+    + "into the Encryption Key Store, Internal File Registry and Download Controller.",
+    operation_id="ingestFileUploadMetadata",
+    tags=["FileIngestService"],
+    status_code=status.HTTP_200_OK,
+    response_description="Received and decrypted data successfully.",
+)
+@inject
+async def ingest_secret(
+    encrypted_payload: EncryptedPayload,
+    upload_metadata_processor: UploadMetadataProcessor = Depends(
+        Provide[Container.upload_metadata_processor]
+    ),
+    _token: IngestTokenAuthContext = require_token,
+):
+    """Decrypt payload, process metadata, file secret and send success event"""
+    file_secret = await upload_metadata_processor.decrypt_secret(
+        encrypted=encrypted_payload
+    )
+
+    secret_id = await upload_metadata_processor.store_secret(file_secret=file_secret)
+    return {"secret_id": secret_id}

--- a/src/fis/adapters/outbound/event_pub.py
+++ b/src/fis/adapters/outbound/event_pub.py
@@ -21,7 +21,7 @@ from ghga_service_commons.utils.utc_dates import now_as_utc
 from hexkit.protocols.eventpub import EventPublisherProtocol
 from pydantic import BaseSettings, Field
 
-from fis.core.models import FileUploadMetadata
+from fis.core.models import UploadMetadataBase
 from fis.ports.outbound.event_pub import EventPublisherPort
 
 
@@ -61,7 +61,7 @@ class EventPubTranslator(EventPublisherPort):
     async def send_file_metadata(
         self,
         *,
-        upload_metadata: FileUploadMetadata,
+        upload_metadata: UploadMetadataBase,
         source_bucket_id: str,
         secret_id: str,
     ):

--- a/src/fis/container.py
+++ b/src/fis/container.py
@@ -21,7 +21,7 @@ from hexkit.providers.akafka import KafkaEventPublisher
 from fis.adapters.outbound.event_pub import EventPubTranslator
 from fis.adapters.outbound.vault import VaultAdapter
 from fis.config import Config
-from fis.core.ingest import UploadMetadataProcessor
+from fis.core.ingest import LegacyUploadMetadataProcessor, UploadMetadataProcessor
 
 
 class Container(ContainerBase):
@@ -33,6 +33,13 @@ class Container(ContainerBase):
         EventPubTranslator, config=config, provider=event_pub_provider
     )
     vault_adapter = get_constructor(VaultAdapter, config=config)
+
+    legacy_upload_metadata_processor = get_constructor(
+        LegacyUploadMetadataProcessor,
+        config=config,
+        event_publisher=event_publisher,
+        vault_adapter=vault_adapter,
+    )
 
     upload_metadata_processor = get_constructor(
         UploadMetadataProcessor,

--- a/src/fis/core/ingest.py
+++ b/src/fis/core/ingest.py
@@ -130,4 +130,4 @@ class UploadMetadataProcessor(UploadMetadataProcessorBase):
         except (ValueError, CryptoError) as error:
             raise self.DecryptionError() from error
 
-        return json.loads(decrypted)["file_secret"]
+        return decrypted

--- a/src/fis/core/models.py
+++ b/src/fis/core/models.py
@@ -17,22 +17,39 @@
 from pydantic import BaseModel
 
 
-class FileUploadMetadataEncrypted(BaseModel):
-    """Encrypted file upload metadata model"""
+class EncryptedPayload(BaseModel):
+    """Generic model for an encrypted payload.
+
+    Can correspond to current/legacy upload metadata or a file secret.
+    """
 
     payload: str
 
 
-class FileUploadMetadata(BaseModel):
-    """Decrypted payload model for S3 upload script output"""
+class UploadMetadataBase(BaseModel):
+    """BaseModel for common parts of different variants of the decrypted payload model
+    representing the S3 upload script output
+    """
 
-    # get all data for now, optimize later if we don't need all of it
     file_id: str
     object_id: str
     part_size: int
     unencrypted_size: int
     encrypted_size: int
-    file_secret: str
     unencrypted_checksum: str
     encrypted_md5_checksums: list[str]
     encrypted_sha256_checksums: list[str]
+
+
+class LegacyUploadMetadata(UploadMetadataBase):
+    """Legacy model including file encryption/decryption secret"""
+
+    file_secret: str
+
+
+class UploadMetadata(UploadMetadataBase):
+    """Current model including a secret ID that can be used to retrieve a stored secret
+    in place of the actual secret.
+    """
+
+    secret_id: str

--- a/src/fis/ports/inbound/ingest.py
+++ b/src/fis/ports/inbound/ingest.py
@@ -46,12 +46,6 @@ class UploadMetadataProcessorPort(Generic[UploadMetadataModel]):
             super().__init__(message)
 
     @abstractmethod
-    async def decrypt_payload(
-        self, *, encrypted: models.EncryptedPayload
-    ) -> UploadMetadataModel:
-        """Decrypt upload metadata using private key"""
-
-    @abstractmethod
     async def populate_by_event(
         self, *, upload_metadata: UploadMetadataModel, secret_id: str
     ):

--- a/src/fis/ports/inbound/ingest.py
+++ b/src/fis/ports/inbound/ingest.py
@@ -14,12 +14,15 @@
 # limitations under the License.
 """Ports for S3 upload metadata ingest"""
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
+from typing import Generic, TypeVar
 
 from fis.core import models
 
+UploadMetadataModel = TypeVar("UploadMetadataModel", bound=models.UploadMetadataBase)
 
-class UploadMetadataProcessorPort(ABC):
+
+class UploadMetadataProcessorPort(Generic[UploadMetadataModel]):
     """Port for"""
 
     class DecryptionError(RuntimeError):
@@ -44,13 +47,13 @@ class UploadMetadataProcessorPort(ABC):
 
     @abstractmethod
     async def decrypt_payload(
-        self, *, encrypted: models.FileUploadMetadataEncrypted
-    ) -> models.FileUploadMetadata:
+        self, *, encrypted: models.EncryptedPayload
+    ) -> UploadMetadataModel:
         """Decrypt upload metadata using private key"""
 
     @abstractmethod
     async def populate_by_event(
-        self, *, upload_metadata: models.FileUploadMetadata, secret_id: str
+        self, *, upload_metadata: UploadMetadataModel, secret_id: str
     ):
         """Send FileUploadValidationSuccess event to be processed by downstream services"""
 

--- a/src/fis/ports/outbound/event_pub.py
+++ b/src/fis/ports/outbound/event_pub.py
@@ -16,7 +16,7 @@
 
 from abc import ABC, abstractmethod
 
-from fis.core.models import FileUploadMetadata
+from fis.core.models import UploadMetadataBase
 
 
 class EventPublisherPort(ABC):
@@ -26,7 +26,7 @@ class EventPublisherPort(ABC):
     async def send_file_metadata(
         self,
         *,
-        upload_metadata: FileUploadMetadata,
+        upload_metadata: UploadMetadataBase,
         source_bucket_id: str,
         secret_id: str,
     ):

--- a/tests/fixtures/joint.py
+++ b/tests/fixtures/joint.py
@@ -33,11 +33,11 @@ from hexkit.providers.akafka.testutils import KafkaFixture, kafka_fixture  # noq
 
 from fis.config import Config, ServiceConfig
 from fis.container import Container
-from fis.core.models import FileUploadMetadata, FileUploadMetadataEncrypted
+from fis.core.models import EncryptedPayload, LegacyUploadMetadata
 from fis.main import get_configured_container, get_rest_api
 from tests.fixtures.config import get_config
 
-TEST_PAYLOAD = FileUploadMetadata(
+TEST_PAYLOAD = LegacyUploadMetadata(
     file_id="abc",
     object_id="happy_little_object",
     part_size=16 * 1024**2,
@@ -58,8 +58,8 @@ class JointFixture:
     container: Container
     keypair: KeyPair
     token: str
-    payload: FileUploadMetadata
-    encrypted_payload: FileUploadMetadataEncrypted
+    payload: LegacyUploadMetadata
+    encrypted_payload: EncryptedPayload
     kafka: KafkaFixture
     rest_client: httpx.AsyncClient
 
@@ -88,7 +88,7 @@ async def joint_fixture(
         ]
     )
 
-    encrypted_payload = FileUploadMetadataEncrypted(
+    encrypted_payload = EncryptedPayload(
         payload=encrypt(
             data=TEST_PAYLOAD.json(),
             key=keypair.public,

--- a/tests/fixtures/joint.py
+++ b/tests/fixtures/joint.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 """Bundle test fixtures together"""
-import base64
-import os
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 
@@ -25,7 +23,6 @@ from ghga_service_commons.api.testing import AsyncTestClient
 from ghga_service_commons.utils.crypt import (
     KeyPair,
     encode_key,
-    encrypt,
     generate_key_pair,
 )
 from ghga_service_commons.utils.simple_token import generate_token_and_hash
@@ -33,17 +30,16 @@ from hexkit.providers.akafka.testutils import KafkaFixture, kafka_fixture  # noq
 
 from fis.config import Config, ServiceConfig
 from fis.container import Container
-from fis.core.models import EncryptedPayload, LegacyUploadMetadata
+from fis.core.models import UploadMetadataBase
 from fis.main import get_configured_container, get_rest_api
 from tests.fixtures.config import get_config
 
-TEST_PAYLOAD = LegacyUploadMetadata(
+TEST_PAYLOAD = UploadMetadataBase(
     file_id="abc",
     object_id="happy_little_object",
     part_size=16 * 1024**2,
     unencrypted_size=50 * 1024**2,
     encrypted_size=50 * 1024**2 + 128,
-    file_secret=base64.b64encode(os.urandom(32)).decode(),
     unencrypted_checksum="def",
     encrypted_md5_checksums=["a", "b", "c"],
     encrypted_sha256_checksums=["a", "b", "c"],
@@ -58,8 +54,7 @@ class JointFixture:
     container: Container
     keypair: KeyPair
     token: str
-    payload: LegacyUploadMetadata
-    encrypted_payload: EncryptedPayload
+    payload: UploadMetadataBase
     kafka: KafkaFixture
     rest_client: httpx.AsyncClient
 
@@ -88,13 +83,6 @@ async def joint_fixture(
         ]
     )
 
-    encrypted_payload = EncryptedPayload(
-        payload=encrypt(
-            data=TEST_PAYLOAD.json(),
-            key=keypair.public,
-        )
-    )
-
     api = get_rest_api(config=config)
 
     async with AsyncTestClient(app=api) as rest_client:
@@ -103,7 +91,6 @@ async def joint_fixture(
             container=container,
             keypair=keypair,
             payload=TEST_PAYLOAD,
-            encrypted_payload=encrypted_payload,
             token=token,
             kafka=kafka_fixture,
             rest_client=rest_client,

--- a/tests/test_api_call.py
+++ b/tests/test_api_call.py
@@ -62,7 +62,9 @@ async def test_api_call(monkeypatch, joint_fixture: JointFixture):  # noqa: F811
         )
         async with event_recorder:
             response = await joint_fixture.rest_client.post(
-                "/ingest", json=joint_fixture.encrypted_payload.dict(), headers=headers
+                "/legacy/ingest",
+                json=joint_fixture.encrypted_payload.dict(),
+                headers=headers,
             )
 
     assert response.status_code == 202
@@ -98,7 +100,7 @@ async def test_api_call(monkeypatch, joint_fixture: JointFixture):  # noqa: F811
 
     # test missing authorization
     response = await joint_fixture.rest_client.post(
-        "/ingest", json=joint_fixture.encrypted_payload.dict()
+        "/legacy/ingest", json=joint_fixture.encrypted_payload.dict()
     )
     assert response.status_code == 403
 
@@ -107,6 +109,6 @@ async def test_api_call(monkeypatch, joint_fixture: JointFixture):  # noqa: F811
         update={"payload": "abcdefghijklmn"}
     )
     response = await joint_fixture.rest_client.post(
-        "/ingest", json=nonsense_payload.dict(), headers=headers
+        "/legacy/ingest", json=nonsense_payload.dict(), headers=headers
     )
     assert response.status_code == 422

--- a/tests/test_api_call.py
+++ b/tests/test_api_call.py
@@ -17,6 +17,7 @@
 """Test actual API call and event publishing"""
 
 import base64
+import json
 import os
 
 import pytest
@@ -47,7 +48,118 @@ async def test_health_check(joint_fixture: JointFixture):  # noqa: F811
 
 
 @pytest.mark.asyncio
-async def test_legacy_api_call(monkeypatch, joint_fixture: JointFixture):  # noqa: F811
+async def test_api_calls(monkeypatch, joint_fixture: JointFixture):  # noqa: F811
+    """Test functionality with incoming API call"""
+    file_secret = base64.b64encode(os.urandom(32)).decode("utf-8")
+    secret_id = "test_secret_id"
+    headers = {"Authorization": f"Bearer {joint_fixture.token}"}
+
+    encrypted_secret = EncryptedPayload(
+        payload=encrypt(data=file_secret, key=joint_fixture.keypair.public)
+    )
+
+    # test secret storage call
+    with monkeypatch.context() as patch:
+        # patch vault call with mock
+        patch.setattr(
+            "fis.adapters.outbound.vault.client.VaultAdapter.store_secret",
+            lambda self, secret: secret_id,
+        )
+        response = await joint_fixture.rest_client.post(
+            "/federated/ingest_secret",
+            json=encrypted_secret.dict(),
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    obtained_secret_id = json.loads(response.content)["secret_id"]
+    assert secret_id == obtained_secret_id
+
+    # test missing authorization
+    response = await joint_fixture.rest_client.post(
+        "/federated/ingest_metadata", json=encrypted_secret.dict()
+    )
+    assert response.status_code == 403
+
+    # test malformed payload
+    nonsense_payload = encrypted_secret.copy(update={"payload": "abcdefghijklmn"})
+    response = await joint_fixture.rest_client.post(
+        "/federated/ingest_metadata", json=nonsense_payload.dict(), headers=headers
+    )
+    assert response.status_code == 422
+
+    # test metadata ingest path
+    payload = UploadMetadata(
+        **joint_fixture.payload.dict(),
+        secret_id=secret_id,
+    )
+    encrypted_payload = EncryptedPayload(
+        payload=encrypt(
+            data=payload.json(),
+            key=joint_fixture.keypair.public,
+        )
+    )
+
+    event_recorder = EventRecorder(
+        kafka_servers=joint_fixture.kafka.config.kafka_servers,
+        topic=joint_fixture.config.publisher_topic,
+    )
+
+    with monkeypatch.context() as patch:
+        async with event_recorder:
+            response = await joint_fixture.rest_client.post(
+                "/federated/ingest_metadata",
+                json=encrypted_payload.dict(),
+                headers=headers,
+            )
+
+    assert response.status_code == 202
+    assert len(event_recorder.recorded_events) == 1
+
+    # can't get exact event time for equality comparison, don't check but get directly
+    # from the recorded event instead
+    expected_upload_date = str(event_recorder.recorded_events[0].payload["upload_date"])
+
+    payload = FileUploadValidationSuccess(
+        upload_date=expected_upload_date,
+        file_id=joint_fixture.payload.file_id,
+        object_id=joint_fixture.payload.object_id,
+        bucket_id=joint_fixture.config.source_bucket_id,
+        decrypted_size=joint_fixture.payload.unencrypted_size,
+        decryption_secret_id=secret_id,
+        content_offset=0,
+        encrypted_part_size=joint_fixture.payload.part_size,
+        encrypted_parts_md5=joint_fixture.payload.encrypted_md5_checksums,
+        encrypted_parts_sha256=joint_fixture.payload.encrypted_sha256_checksums,
+        decrypted_sha256=joint_fixture.payload.unencrypted_checksum,
+    )
+
+    expected_event = ExpectedEvent(
+        payload=payload.dict(),
+        type_=joint_fixture.config.publisher_type,
+        key=joint_fixture.payload.file_id,
+    )
+
+    check_recorded_events(
+        recorded_events=event_recorder.recorded_events, expected_events=[expected_event]
+    )
+
+    # test missing authorization
+    response = await joint_fixture.rest_client.post(
+        "/federated/ingest_metadata", json=encrypted_payload.dict()
+    )
+    assert response.status_code == 403
+
+    # test malformed payload
+    nonsense_payload = encrypted_payload.copy(update={"payload": "abcdefghijklmn"})
+    response = await joint_fixture.rest_client.post(
+        "/federated/ingest_metadata", json=nonsense_payload.dict(), headers=headers
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_legacy_api_calls(monkeypatch, joint_fixture: JointFixture):  # noqa: F811
     """Test functionality with incoming API call"""
     payload = LegacyUploadMetadata(
         **joint_fixture.payload.dict(),

--- a/tests/test_api_call.py
+++ b/tests/test_api_call.py
@@ -105,13 +105,12 @@ async def test_api_calls(monkeypatch, joint_fixture: JointFixture):  # noqa: F81
         topic=joint_fixture.config.publisher_topic,
     )
 
-    with monkeypatch.context() as patch:
-        async with event_recorder:
-            response = await joint_fixture.rest_client.post(
-                "/federated/ingest_metadata",
-                json=encrypted_payload.dict(),
-                headers=headers,
-            )
+    async with event_recorder:
+        response = await joint_fixture.rest_client.post(
+            "/federated/ingest_metadata",
+            json=encrypted_payload.dict(),
+            headers=headers,
+        )
 
     assert response.status_code == 202
     assert len(event_recorder.recorded_events) == 1

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -15,10 +15,13 @@
 
 """Test ingest functions"""
 
+import base64
+import os
+
 import pytest
 from ghga_service_commons.utils.crypt import encrypt, generate_key_pair
 
-from fis.core.models import EncryptedPayload
+from fis.core.models import EncryptedPayload, LegacyUploadMetadata, UploadMetadata
 from tests.fixtures.joint import (  # noqa: F401
     JointFixture,
     KafkaFixture,
@@ -31,13 +34,50 @@ from tests.fixtures.joint import (  # noqa: F401
 async def test_decryption_happy(joint_fixture: JointFixture):  # noqa: F811
     """Test decryption with valid keypair and correct file upload metadata format."""
     upload_metadata_processor = (
-        await joint_fixture.container.legacy_upload_metadata_processor()
+        await joint_fixture.container.upload_metadata_processor()
+    )
+
+    payload = UploadMetadata(
+        **joint_fixture.payload.dict(),
+        secret_id="test_secret_id",
+    )
+
+    encrypted_payload = EncryptedPayload(
+        payload=encrypt(
+            data=payload.json(),
+            key=joint_fixture.keypair.public,
+        )
     )
 
     processed_payload = await upload_metadata_processor.decrypt_payload(
-        encrypted=joint_fixture.encrypted_payload
+        encrypted=encrypted_payload
     )
-    assert processed_payload == joint_fixture.payload
+    assert processed_payload == payload
+
+
+@pytest.mark.asyncio
+async def test_legacy_decryption_happy(joint_fixture: JointFixture):  # noqa: F811
+    """Test decryption with valid keypair and correct file upload metadata format."""
+    upload_metadata_processor = (
+        await joint_fixture.container.legacy_upload_metadata_processor()
+    )
+
+    payload = LegacyUploadMetadata(
+        **joint_fixture.payload.dict(),
+        file_secret=base64.b64encode(os.urandom(32)).decode("utf-8"),
+    )
+
+    encrypted_payload = EncryptedPayload(
+        payload=encrypt(
+            data=payload.json(),
+            key=joint_fixture.keypair.public,
+        )
+    )
+
+    processed_payload = await upload_metadata_processor.decrypt_payload(
+        encrypted=encrypted_payload
+    )
+    assert processed_payload == payload
 
 
 @pytest.mark.asyncio
@@ -50,7 +90,7 @@ async def test_decryption_sad(joint_fixture: JointFixture):  # noqa: F811
     # test faulty payload
     encrypted_payload = EncryptedPayload(
         payload=encrypt(
-            data=joint_fixture.payload.json(exclude={"file_secret"}),
+            data=joint_fixture.payload.json(),
             key=joint_fixture.keypair.public,
         )
     )
@@ -61,8 +101,47 @@ async def test_decryption_sad(joint_fixture: JointFixture):  # noqa: F811
     # test wrong key
     keypair2 = generate_key_pair()
 
+    payload = UploadMetadata(
+        **joint_fixture.payload.dict(),
+        secret_id="test_secret_id",
+    )
+
     encrypted_payload = EncryptedPayload(
-        payload=encrypt(data=joint_fixture.payload.json(), key=keypair2.public)
+        payload=encrypt(data=payload.json(), key=keypair2.public)
+    )
+
+    with pytest.raises(upload_metadata_processor.DecryptionError):
+        await upload_metadata_processor.decrypt_payload(encrypted=encrypted_payload)
+
+
+@pytest.mark.asyncio
+async def test_legacy_decryption_sad(joint_fixture: JointFixture):  # noqa: F811
+    """Test decryption throws correct errors for payload and key issues"""
+    upload_metadata_processor = (
+        await joint_fixture.container.upload_metadata_processor()
+    )
+
+    # test faulty payload
+    encrypted_payload = EncryptedPayload(
+        payload=encrypt(
+            data=joint_fixture.payload.json(),
+            key=joint_fixture.keypair.public,
+        )
+    )
+
+    with pytest.raises(upload_metadata_processor.WrongDecryptedFormatError):
+        await upload_metadata_processor.decrypt_payload(encrypted=encrypted_payload)
+
+    # test wrong key
+    keypair2 = generate_key_pair()
+
+    payload = LegacyUploadMetadata(
+        **joint_fixture.payload.dict(),
+        file_secret=base64.b64encode(os.urandom(32)).decode("utf-8"),
+    )
+
+    encrypted_payload = EncryptedPayload(
+        payload=encrypt(data=payload.json(), key=keypair2.public)
     )
 
     with pytest.raises(upload_metadata_processor.DecryptionError):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -18,7 +18,7 @@
 import pytest
 from ghga_service_commons.utils.crypt import encrypt, generate_key_pair
 
-from fis.core.models import FileUploadMetadataEncrypted
+from fis.core.models import EncryptedPayload
 from tests.fixtures.joint import (  # noqa: F401
     JointFixture,
     KafkaFixture,
@@ -31,7 +31,7 @@ from tests.fixtures.joint import (  # noqa: F401
 async def test_decryption_happy(joint_fixture: JointFixture):  # noqa: F811
     """Test decryption with valid keypair and correct file upload metadata format."""
     upload_metadata_processor = (
-        await joint_fixture.container.upload_metadata_processor()
+        await joint_fixture.container.legacy_upload_metadata_processor()
     )
 
     processed_payload = await upload_metadata_processor.decrypt_payload(
@@ -44,11 +44,11 @@ async def test_decryption_happy(joint_fixture: JointFixture):  # noqa: F811
 async def test_decryption_sad(joint_fixture: JointFixture):  # noqa: F811
     """Test decryption throws correct errors for payload and key issues"""
     upload_metadata_processor = (
-        await joint_fixture.container.upload_metadata_processor()
+        await joint_fixture.container.legacy_upload_metadata_processor()
     )
 
     # test faulty payload
-    encrypted_payload = FileUploadMetadataEncrypted(
+    encrypted_payload = EncryptedPayload(
         payload=encrypt(
             data=joint_fixture.payload.json(exclude={"file_secret"}),
             key=joint_fixture.keypair.public,
@@ -61,7 +61,7 @@ async def test_decryption_sad(joint_fixture: JointFixture):  # noqa: F811
     # test wrong key
     keypair2 = generate_key_pair()
 
-    encrypted_payload = FileUploadMetadataEncrypted(
+    encrypted_payload = EncryptedPayload(
         payload=encrypt(data=joint_fixture.payload.json(), key=keypair2.public)
     )
 


### PR DESCRIPTION
This adds two new endpoints for secret ingest and S3 upload metadata ingest with secret_id instead of the secret.
The old endpoint is marked as deprecated now and adjusted.

Feel free to propose more fitting paths for the routes